### PR TITLE
Add ProductShowcase component and format builder registry

### DIFF
--- a/builder-registry.ts
+++ b/builder-registry.ts
@@ -7,6 +7,7 @@ import Footer from "./client/components/Footer";
 import HeroSection from "./client/components/HeroSection";
 import Navigation from "./client/components/Navigation";
 import ProductGrid from "./client/components/ProductGrid";
+import ProductShowcase from "./client/components/ProductShowcase";
 import StyleThemes from "./client/components/StyleThemes";
 import { Button } from "./client/components/ui/button";
 import { Badge } from "./client/components/ui/badge";
@@ -19,10 +20,25 @@ Builder.registerComponent(Button, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/click.svg",
   inputs: [
     { name: "children", type: "string", defaultValue: "Shop New Arrivals" },
-    { name: "variant", type: "string", enum: ["default", "destructive", "outline", "secondary", "ghost", "link"], defaultValue: "default" },
-    { name: "size", type: "string", enum: ["default", "sm", "lg", "icon"], defaultValue: "lg" },
+    {
+      name: "variant",
+      type: "string",
+      enum: ["default", "destructive", "outline", "secondary", "ghost", "link"],
+      defaultValue: "default",
+    },
+    {
+      name: "size",
+      type: "string",
+      enum: ["default", "sm", "lg", "icon"],
+      defaultValue: "lg",
+    },
     { name: "className", type: "string" },
-    { name: "type", type: "string", enum: ["button", "submit", "reset"], defaultValue: "button" },
+    {
+      name: "type",
+      type: "string",
+      enum: ["button", "submit", "reset"],
+      defaultValue: "button",
+    },
   ],
 });
 
@@ -31,7 +47,12 @@ Builder.registerComponent(Badge, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/badge.svg",
   inputs: [
     { name: "children", type: "string", defaultValue: "Style Guide" },
-    { name: "variant", type: "string", enum: ["default", "secondary", "destructive", "outline"], defaultValue: "outline" },
+    {
+      name: "variant",
+      type: "string",
+      enum: ["default", "secondary", "destructive", "outline"],
+      defaultValue: "outline",
+    },
     { name: "className", type: "string", defaultValue: "w-fit mb-4 mx-auto" },
   ],
 });
@@ -41,23 +62,74 @@ Builder.registerComponent(CallToActionSection, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/volume.svg",
   inputs: [
     { name: "title", type: "string", defaultValue: "The Summer Style Guide" },
-    { name: "description", type: "string", defaultValue: "Discover the perfect pieces for warm weather entertaining, coastal getaways, and everything in between. Our curated selection makes summer dressing effortless and elegant." },
-    { name: "buttons", type: "list",
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Discover the perfect pieces for warm weather entertaining, coastal getaways, and everything in between. Our curated selection makes summer dressing effortless and elegant.",
+    },
+    {
+      name: "buttons",
+      type: "list",
       defaultValue: [
-        { text: "Explore the Guide", href: "/style-guide", variant: "default", className: "btn-primary" }
+        {
+          text: "Explore the Guide",
+          href: "/style-guide",
+          variant: "default",
+          className: "btn-primary",
+        },
       ],
       subFields: [
         { name: "text", type: "string" },
         { name: "href", type: "string" },
-        { name: "variant", type: "string", enum: ["default", "outline", "ghost"], defaultValue: "default" },
+        {
+          name: "variant",
+          type: "string",
+          enum: ["default", "outline", "ghost"],
+          defaultValue: "default",
+        },
         { name: "className", type: "string", defaultValue: "btn-primary" },
-      ] },
-    { name: "badge", type: "string", required: false, defaultValue: "Style Guide" },
-    { name: "image", type: "string", required: false, defaultValue: "https://images.pexels.com/photos/32796818/pexels-photo-32796818.jpeg" },
-    { name: "imageAlt", type: "string", required: false, defaultValue: "Summer Style Guide" },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-gradient-to-r from-sage-100 to-cream-100" },
-    { name: "layout", type: "string", enum: ["centered", "side-by-side"], required: false, defaultValue: "side-by-side" },
-    { name: "imagePosition", type: "string", enum: ["left", "right"], required: false, defaultValue: "left" },
+      ],
+    },
+    {
+      name: "badge",
+      type: "string",
+      required: false,
+      defaultValue: "Style Guide",
+    },
+    {
+      name: "image",
+      type: "string",
+      required: false,
+      defaultValue:
+        "https://images.pexels.com/photos/32796818/pexels-photo-32796818.jpeg",
+    },
+    {
+      name: "imageAlt",
+      type: "string",
+      required: false,
+      defaultValue: "Summer Style Guide",
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-gradient-to-r from-sage-100 to-cream-100",
+    },
+    {
+      name: "layout",
+      type: "string",
+      enum: ["centered", "side-by-side"],
+      required: false,
+      defaultValue: "side-by-side",
+    },
+    {
+      name: "imagePosition",
+      type: "string",
+      enum: ["left", "right"],
+      required: false,
+      defaultValue: "left",
+    },
   ],
 });
 
@@ -66,36 +138,58 @@ Builder.registerComponent(CollectionsShowcase, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/layout-grid.svg",
   inputs: [
     { name: "title", type: "string", defaultValue: "Shop Collections" },
-    { name: "description", type: "string", defaultValue: "Explore our carefully curated collections designed for every occasion and season." },
-    { name: "collections", type: "list",
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Explore our carefully curated collections designed for every occasion and season.",
+    },
+    {
+      name: "collections",
+      type: "list",
       defaultValue: [
         {
           title: "Women's Collection",
           description: "Timeless pieces for the modern woman",
-          image: "https://images.pexels.com/photos/5704846/pexels-photo-5704846.jpeg",
-          href: "/collections/women"
+          image:
+            "https://images.pexels.com/photos/5704846/pexels-photo-5704846.jpeg",
+          href: "/collections/women",
         },
         {
           title: "Men's Collection",
           description: "Classic American style essentials",
-          image: "https://images.pexels.com/photos/5264948/pexels-photo-5264948.jpeg",
-          href: "/collections/men"
+          image:
+            "https://images.pexels.com/photos/5264948/pexels-photo-5264948.jpeg",
+          href: "/collections/men",
         },
         {
           title: "Accessories",
           description: "Perfect finishing touches",
-          image: "https://images.pexels.com/photos/1870926/pexels-photo-1870926.jpeg",
-          href: "/collections/accessories"
-        }
+          image:
+            "https://images.pexels.com/photos/1870926/pexels-photo-1870926.jpeg",
+          href: "/collections/accessories",
+        },
       ],
       subFields: [
         { name: "title", type: "string" },
         { name: "description", type: "string" },
         { name: "image", type: "string" },
         { name: "href", type: "string" },
-      ] },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-muted/30" },
-    { name: "columns", type: "string", enum: ["1", "2", "3", "4"], required: false, defaultValue: "3" },
+      ],
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-muted/30",
+    },
+    {
+      name: "columns",
+      type: "string",
+      enum: ["1", "2", "3", "4"],
+      required: false,
+      defaultValue: "3",
+    },
   ],
 });
 
@@ -104,8 +198,15 @@ Builder.registerComponent(ColorPalette, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/palette.svg",
   inputs: [
     { name: "title", type: "string", defaultValue: "Summer Color Palette" },
-    { name: "description", type: "string", defaultValue: "This season's colors are inspired by coastal landscapes and summer sunsets. Mix and match these hues for effortless coordination." },
-    { name: "colors", type: "list",
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "This season's colors are inspired by coastal landscapes and summer sunsets. Mix and match these hues for effortless coordination.",
+    },
+    {
+      name: "colors",
+      type: "list",
       defaultValue: [
         { name: "Ocean Blue", color: "bg-blue-500", hex: "#3B82F6" },
         { name: "Sage Green", color: "bg-green-400", hex: "#4ADE80" },
@@ -118,9 +219,21 @@ Builder.registerComponent(ColorPalette, {
         { name: "name", type: "string" },
         { name: "color", type: "string" },
         { name: "hex", type: "color" },
-      ] },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-background" },
-    { name: "columns", type: "string", enum: ["2", "3", "4", "5", "6"], required: false, defaultValue: "6" },
+      ],
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-background",
+    },
+    {
+      name: "columns",
+      type: "string",
+      enum: ["2", "3", "4", "5", "6"],
+      required: false,
+      defaultValue: "6",
+    },
   ],
 });
 
@@ -128,51 +241,123 @@ Builder.registerComponent(FeaturesSection, {
   name: "FeaturesSection",
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/settings.svg",
   inputs: [
-    { name: "features", type: "list",
+    {
+      name: "features",
+      type: "list",
       defaultValue: [
-        { icon: "🚚", title: "Free Shipping", description: "On orders over $150" },
-        { icon: "🔄", title: "Easy Returns", description: "30-day return policy" },
-        { icon: "🛡️", title: "Secure Payment", description: "Your data is protected" },
-        { icon: "⭐", title: "Premium Quality", description: "Finest materials and craftsmanship" },
+        {
+          icon: "🚚",
+          title: "Free Shipping",
+          description: "On orders over $150",
+        },
+        {
+          icon: "🔄",
+          title: "Easy Returns",
+          description: "30-day return policy",
+        },
+        {
+          icon: "🛡️",
+          title: "Secure Payment",
+          description: "Your data is protected",
+        },
+        {
+          icon: "⭐",
+          title: "Premium Quality",
+          description: "Finest materials and craftsmanship",
+        },
       ],
       subFields: [
         { name: "icon", type: "string" },
         { name: "title", type: "string" },
         { name: "description", type: "string" },
-      ] },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-background" },
-    { name: "columns", type: "string", enum: ["2", "3", "4"], required: false, defaultValue: "4" },
+      ],
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-background",
+    },
+    {
+      name: "columns",
+      type: "string",
+      enum: ["2", "3", "4"],
+      required: false,
+      defaultValue: "4",
+    },
   ],
 });
 
 Builder.registerComponent(Footer, {
   name: "Footer",
-  image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/align-box-bottom-center.svg",
-  inputs: [
-    { name: "showStayInTouch", type: "boolean", defaultValue: true },
-  ],
+  image:
+    "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/align-box-bottom-center.svg",
+  inputs: [{ name: "showStayInTouch", type: "boolean", defaultValue: true }],
 });
 
 Builder.registerComponent(HeroSection, {
   name: "HeroSection",
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/photo.svg",
   inputs: [
-    { name: "badge", type: "string", required: false, defaultValue: "New Spring Collection" },
+    {
+      name: "badge",
+      type: "string",
+      required: false,
+      defaultValue: "New Spring Collection",
+    },
     { name: "title", type: "string", defaultValue: "Timeless Style," },
-    { name: "highlightedText", type: "string", required: false, defaultValue: "Modern Living" },
-    { name: "description", type: "string", defaultValue: "Discover our curated collection of classic American clothing designed for life's memorable moments." },
-    { name: "buttons", type: "list",
+    {
+      name: "highlightedText",
+      type: "string",
+      required: false,
+      defaultValue: "Modern Living",
+    },
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Discover our curated collection of classic American clothing designed for life's memorable moments.",
+    },
+    {
+      name: "buttons",
+      type: "list",
       defaultValue: [
-        { text: "Shop New Arrivals", href: "/collections/new-arrivals", variant: "default" },
-        { text: "View Style Guide", href: "/style-guide", variant: "outline" }
+        {
+          text: "Shop New Arrivals",
+          href: "/collections/new-arrivals",
+          variant: "default",
+        },
+        { text: "View Style Guide", href: "/style-guide", variant: "outline" },
       ],
       subFields: [
         { name: "text", type: "string" },
         { name: "href", type: "string" },
-        { name: "variant", type: "string", enum: ["default", "outline", "destructive", "secondary", "ghost", "link"], defaultValue: "default" },
-      ] },
-    { name: "image", type: "string", defaultValue: "https://images.pexels.com/photos/27733947/pexels-photo-27733947.jpeg" },
-    { name: "imageAlt", type: "string", defaultValue: "Spring Collection Hero" },
+        {
+          name: "variant",
+          type: "string",
+          enum: [
+            "default",
+            "outline",
+            "destructive",
+            "secondary",
+            "ghost",
+            "link",
+          ],
+          defaultValue: "default",
+        },
+      ],
+    },
+    {
+      name: "image",
+      type: "string",
+      defaultValue:
+        "https://images.pexels.com/photos/27733947/pexels-photo-27733947.jpeg",
+    },
+    {
+      name: "imageAlt",
+      type: "string",
+      defaultValue: "Spring Collection Hero",
+    },
     { name: "backgroundColor", type: "string", required: false },
   ],
 });
@@ -187,14 +372,59 @@ Builder.registerComponent(ProductGrid, {
   name: "ProductGrid",
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/grid-dots.svg",
   inputs: [
-    { name: "title", type: "string", required: false, defaultValue: "Featured Pieces" },
-    { name: "description", type: "string", required: false, defaultValue: "Handpicked favorites that embody our commitment to quality, comfort, and timeless style." },
-    { name: "products", type: "list",
+    {
+      name: "title",
+      type: "string",
+      required: false,
+      defaultValue: "Featured Pieces",
+    },
+    {
+      name: "description",
+      type: "string",
+      required: false,
+      defaultValue:
+        "Handpicked favorites that embody our commitment to quality, comfort, and timeless style.",
+    },
+    {
+      name: "products",
+      type: "list",
       defaultValue: [
-        { id: 1, name: "Classic Cotton Shirt", price: 128, image: "https://images.pexels.com/photos/6276012/pexels-photo-6276012.jpeg", category: "Men", isNew: true },
-        { id: 2, name: "Linen Summer Dress", price: 198, originalPrice: 248, image: "https://images.pexels.com/photos/1887465/pexels-photo-1887465.jpeg", category: "Women" },
-        { id: 3, name: "Leather Weekend Bag", price: 425, image: "https://images.pexels.com/photos/8365688/pexels-photo-8365688.jpeg", category: "Accessories", isNew: true },
-        { id: 4, name: "Cashmere Cardigan", price: 285, originalPrice: 325, image: "https://images.pexels.com/photos/4210854/pexels-photo-4210854.jpeg", category: "Women" },
+        {
+          id: 1,
+          name: "Classic Cotton Shirt",
+          price: 128,
+          image:
+            "https://images.pexels.com/photos/6276012/pexels-photo-6276012.jpeg",
+          category: "Men",
+          isNew: true,
+        },
+        {
+          id: 2,
+          name: "Linen Summer Dress",
+          price: 198,
+          originalPrice: 248,
+          image:
+            "https://images.pexels.com/photos/1887465/pexels-photo-1887465.jpeg",
+          category: "Women",
+        },
+        {
+          id: 3,
+          name: "Leather Weekend Bag",
+          price: 425,
+          image:
+            "https://images.pexels.com/photos/8365688/pexels-photo-8365688.jpeg",
+          category: "Accessories",
+          isNew: true,
+        },
+        {
+          id: 4,
+          name: "Cashmere Cardigan",
+          price: 285,
+          originalPrice: 325,
+          image:
+            "https://images.pexels.com/photos/4210854/pexels-photo-4210854.jpeg",
+          category: "Women",
+        },
       ],
       subFields: [
         { name: "id", type: "number", required: false },
@@ -206,16 +436,59 @@ Builder.registerComponent(ProductGrid, {
         { name: "description", type: "string", required: false },
         { name: "isNew", type: "boolean", required: false },
         { name: "isSale", type: "boolean", required: false },
-      ] },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-background" },
-    { name: "columns", type: "string", enum: ["2", "3", "4"], required: false, defaultValue: "4" },
-    { name: "viewMode", type: "string", enum: ["grid", "list"], required: false, defaultValue: "grid" },
-    { name: "showViewAllButton", type: "boolean", required: false, defaultValue: true },
+      ],
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-background",
+    },
+    {
+      name: "columns",
+      type: "string",
+      enum: ["2", "3", "4"],
+      required: false,
+      defaultValue: "4",
+    },
+    {
+      name: "viewMode",
+      type: "string",
+      enum: ["grid", "list"],
+      required: false,
+      defaultValue: "grid",
+    },
+    {
+      name: "showViewAllButton",
+      type: "boolean",
+      required: false,
+      defaultValue: true,
+    },
     { name: "viewAllButtonText", type: "string", required: false },
-    { name: "viewAllButtonHref", type: "string", required: false, defaultValue: "/collections/all" },
-    { name: "showAddToCart", type: "boolean", required: false, defaultValue: false },
-    { name: "showCategory", type: "boolean", required: false, defaultValue: true },
-    { name: "showColors", type: "boolean", required: false, defaultValue: false },
+    {
+      name: "viewAllButtonHref",
+      type: "string",
+      required: false,
+      defaultValue: "/collections/all",
+    },
+    {
+      name: "showAddToCart",
+      type: "boolean",
+      required: false,
+      defaultValue: false,
+    },
+    {
+      name: "showCategory",
+      type: "boolean",
+      required: false,
+      defaultValue: true,
+    },
+    {
+      name: "showColors",
+      type: "boolean",
+      required: false,
+      defaultValue: false,
+    },
   ],
 });
 
@@ -224,13 +497,21 @@ Builder.registerComponent(StyleThemes, {
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/shirt.svg",
   inputs: [
     { name: "title", type: "string", defaultValue: "Three Ways to Summer" },
-    { name: "description", type: "string", defaultValue: "Whether you're planning a coastal escape, hosting garden parties, or navigating city summers, we have the perfect pieces for every occasion." },
-    { name: "themes", type: "list",
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Whether you're planning a coastal escape, hosting garden parties, or navigating city summers, we have the perfect pieces for every occasion.",
+    },
+    {
+      name: "themes",
+      type: "list",
       defaultValue: [
         {
           title: "Coastal Elegance",
           description: "Effortless pieces perfect for seaside escapes",
-          image: "https://images.pexels.com/photos/32796818/pexels-photo-32796818.jpeg",
+          image:
+            "https://images.pexels.com/photos/32796818/pexels-photo-32796818.jpeg",
           icon: "🌊",
           products: [
             "Linen Button-Down Shirt",
@@ -242,7 +523,8 @@ Builder.registerComponent(StyleThemes, {
         {
           title: "Garden Party Ready",
           description: "Sophisticated looks for outdoor entertaining",
-          image: "https://images.pexels.com/photos/17294877/pexels-photo-17294877.png",
+          image:
+            "https://images.pexels.com/photos/17294877/pexels-photo-17294877.png",
           icon: "☀️",
           products: [
             "Silk Print Dress",
@@ -254,7 +536,8 @@ Builder.registerComponent(StyleThemes, {
         {
           title: "City Summer",
           description: "Professional pieces that beat the heat",
-          image: "https://images.pexels.com/photos/5717325/pexels-photo-5717325.jpeg",
+          image:
+            "https://images.pexels.com/photos/5717325/pexels-photo-5717325.jpeg",
           icon: "✨",
           products: [
             "Lightweight Blazer",
@@ -270,9 +553,21 @@ Builder.registerComponent(StyleThemes, {
         { name: "image", type: "string" },
         { name: "icon", type: "string" },
         { name: "products", type: "list" },
-      ] },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-background" },
-    { name: "columns", type: "string", enum: ["1", "2", "3", "4"], required: false, defaultValue: "3" },
+      ],
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-background",
+    },
+    {
+      name: "columns",
+      type: "string",
+      enum: ["1", "2", "3", "4"],
+      required: false,
+      defaultValue: "3",
+    },
   ],
 });
 
@@ -280,91 +575,118 @@ Builder.registerComponent(withChildren(HeroWithChildren), {
   name: "HeroWithChildren",
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/photo.svg",
   inputs: [
-    { name: "image", type: "string", defaultValue: "https://images.pexels.com/photos/27733947/pexels-photo-27733947.jpeg" },
-    { name: "imageAlt", type: "string", defaultValue: "Spring Collection Hero" },
-    { name: "backgroundColor", type: "string", required: false, defaultValue: "bg-gradient-to-r from-navy-50 to-cream-50" },
+    {
+      name: "image",
+      type: "string",
+      defaultValue:
+        "https://images.pexels.com/photos/27733947/pexels-photo-27733947.jpeg",
+    },
+    {
+      name: "imageAlt",
+      type: "string",
+      defaultValue: "Spring Collection Hero",
+    },
+    {
+      name: "backgroundColor",
+      type: "string",
+      required: false,
+      defaultValue: "bg-gradient-to-r from-navy-50 to-cream-50",
+    },
   ],
   defaultChildren: [
     {
-      '@type': '@builder.io/sdk:Element',
+      "@type": "@builder.io/sdk:Element",
       component: {
-        name: 'Badge',
+        name: "Badge",
         options: {
-          children: 'New Spring Collection',
-          variant: 'secondary',
-          className: 'w-fit',
+          children: "New Spring Collection",
+          variant: "secondary",
+          className: "w-fit",
         },
       },
     },
     {
-      '@type': '@builder.io/sdk:Element',
+      "@type": "@builder.io/sdk:Element",
       component: {
-        name: 'h1',
+        name: "h1",
         options: {
-          className: 'text-4xl lg:text-6xl font-serif font-bold leading-tight',
+          className: "text-4xl lg:text-6xl font-serif font-bold leading-tight",
         },
       },
       children: [
-        { '@type': '@builder.io/sdk:Element', component: { name: 'Text', options: { text: 'Timeless Style, ' } } },
         {
-          '@type': '@builder.io/sdk:Element',
+          "@type": "@builder.io/sdk:Element",
+          component: { name: "Text", options: { text: "Timeless Style, " } },
+        },
+        {
+          "@type": "@builder.io/sdk:Element",
           component: {
-            name: 'span',
-            options: { className: 'text-primary' },
+            name: "span",
+            options: { className: "text-primary" },
           },
           children: [
-            { '@type': '@builder.io/sdk:Element', component: { name: 'Text', options: { text: 'Modern Living' } } }
-          ]
-        }
-      ]
+            {
+              "@type": "@builder.io/sdk:Element",
+              component: { name: "Text", options: { text: "Modern Living" } },
+            },
+          ],
+        },
+      ],
     },
     {
-      '@type': '@builder.io/sdk:Element',
+      "@type": "@builder.io/sdk:Element",
       component: {
-        name: 'p',
+        name: "p",
         options: {
-          className: 'text-lg text-muted-foreground max-w-md',
+          className: "text-lg text-muted-foreground max-w-md",
         },
       },
       children: [
-        { '@type': '@builder.io/sdk:Element', component: { name: 'Text', options: { text: "Discover our curated collection of classic American clothing designed for life's memorable moments." } } }
-      ]
+        {
+          "@type": "@builder.io/sdk:Element",
+          component: {
+            name: "Text",
+            options: {
+              text: "Discover our curated collection of classic American clothing designed for life's memorable moments.",
+            },
+          },
+        },
+      ],
     },
     {
-      '@type': '@builder.io/sdk:Element',
+      "@type": "@builder.io/sdk:Element",
       component: {
-        name: 'div',
-        options: { className: 'flex flex-row gap-4' },
+        name: "div",
+        options: { className: "flex flex-row gap-4" },
       },
       children: [
         {
-          '@type': '@builder.io/sdk:Element',
+          "@type": "@builder.io/sdk:Element",
           component: {
-            name: 'Button',
+            name: "Button",
             options: {
-              children: 'Shop New Arrivals',
-              variant: 'default',
-              size: 'lg',
-              className: 'btn-primary',
+              children: "Shop New Arrivals",
+              variant: "default",
+              size: "lg",
+              className: "btn-primary",
             },
           },
         },
         {
-          '@type': '@builder.io/sdk:Element',
+          "@type": "@builder.io/sdk:Element",
           component: {
-            name: 'Button',
+            name: "Button",
             options: {
-              children: 'View Style Guide',
-              variant: 'outline',
-              size: 'lg',
+              children: "View Style Guide",
+              variant: "outline",
+              size: "lg",
             },
           },
-        }
-      ]
-    }
-  ]
+        },
+      ],
+    },
+  ],
 });
-
 
 Builder.register("editor.settings", {
   designTokens: {
@@ -402,13 +724,19 @@ Builder.register("editor.settings", {
       { name: "Primary", value: "hsl(var(--primary))" },
       { name: "Primary Foreground", value: "hsl(var(--primary-foreground))" },
       { name: "Secondary", value: "hsl(var(--secondary))" },
-      { name: "Secondary Foreground", value: "hsl(var(--secondary-foreground))" },
+      {
+        name: "Secondary Foreground",
+        value: "hsl(var(--secondary-foreground))",
+      },
       { name: "Accent", value: "hsl(var(--accent))" },
       { name: "Accent Foreground", value: "hsl(var(--accent-foreground))" },
       { name: "Muted", value: "hsl(var(--muted))" },
       { name: "Muted Foreground", value: "hsl(var(--muted-foreground))" },
       { name: "Destructive", value: "hsl(var(--destructive))" },
-      { name: "Destructive Foreground", value: "hsl(var(--destructive-foreground))" },
+      {
+        name: "Destructive Foreground",
+        value: "hsl(var(--destructive-foreground))",
+      },
       { name: "Background", value: "hsl(var(--background))" },
       { name: "Foreground", value: "hsl(var(--foreground))" },
       { name: "Card", value: "hsl(var(--card))" },
@@ -423,6 +751,5 @@ Builder.register("editor.settings", {
       { name: "Inter", value: "'Inter', system-ui, sans-serif" },
       { name: "Playfair Display", value: "'Playfair Display', Georgia, serif" },
     ],
-  }
+  },
 });
-

--- a/builder-registry.ts
+++ b/builder-registry.ts
@@ -492,6 +492,65 @@ Builder.registerComponent(ProductGrid, {
   ],
 });
 
+Builder.registerComponent(ProductShowcase, {
+  name: "ProductShowcase",
+  image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/photo-collage.svg",
+  inputs: [
+    {
+      name: "products",
+      type: "list",
+      defaultValue: [
+        {
+          title: "The Linen",
+          subtitle: "Shirt",
+          image:
+            "https://images.pexels.com/photos/6276012/pexels-photo-6276012.jpeg",
+          href: "/collections/shirts/linen-shirt",
+          alt: "White linen shirt",
+        },
+        {
+          title: "The White",
+          subtitle: "Dress",
+          image:
+            "https://images.pexels.com/photos/1887465/pexels-photo-1887465.jpeg",
+          href: "/collections/dresses/white-dress",
+          alt: "White summer dress",
+        },
+        {
+          title: "The Wicker",
+          subtitle: "Bag",
+          image:
+            "https://images.pexels.com/photos/8365688/pexels-photo-8365688.jpeg",
+          href: "/collections/accessories/wicker-bag",
+          alt: "Wicker handbag",
+        },
+      ],
+      subFields: [
+        { name: "title", type: "string" },
+        { name: "subtitle", type: "string", required: false },
+        { name: "image", type: "string" },
+        { name: "href", type: "string" },
+        { name: "alt", type: "string", required: false },
+      ],
+    },
+    { name: "className", type: "string", required: false },
+    {
+      name: "imageHeight",
+      type: "string",
+      required: false,
+      defaultValue: "h-[400px] md:h-[500px] lg:h-[632px]",
+    },
+    { name: "gap", type: "string", required: false, defaultValue: "gap-1.5" },
+    {
+      name: "showTitles",
+      type: "boolean",
+      required: false,
+      defaultValue: true,
+    },
+    { name: "zoomScale", type: "number", required: false, defaultValue: 1.1 },
+  ],
+});
+
 Builder.registerComponent(StyleThemes, {
   name: "StyleThemes",
   image: "https://cdn.jsdelivr.net/npm/@tabler/icons/icons/shirt.svg",

--- a/client/components/ProductShowcase.tsx
+++ b/client/components/ProductShowcase.tsx
@@ -1,0 +1,74 @@
+import { Link } from "react-router-dom";
+
+export interface ProductItem {
+  title: string;
+  subtitle?: string;
+  image: string;
+  href: string;
+  alt?: string;
+}
+
+interface ProductShowcaseProps {
+  products: ProductItem[];
+  className?: string;
+  imageHeight?: string;
+  gap?: string;
+  showTitles?: boolean;
+  zoomScale?: number;
+}
+
+const ProductShowcase = ({
+  products = [],
+  className = "",
+  imageHeight = "h-[400px] md:h-[500px] lg:h-[632px]",
+  gap = "gap-1.5",
+  showTitles = true,
+  zoomScale = 1.1,
+}: ProductShowcaseProps) => {
+  const zoomClass = `hover:scale-[${zoomScale}]`;
+
+  return (
+    <section className={`w-full ${className}`}>
+      <div className={`flex flex-col lg:flex-row ${gap} w-full`}>
+        {products.map((product, index) => (
+          <Link
+            key={index}
+            to={product.href}
+            className="group block flex-1 relative overflow-hidden bg-white"
+          >
+            <div className="relative overflow-hidden">
+              <img
+                src={product.image}
+                alt={product.alt || product.title}
+                className={`w-full ${imageHeight} object-cover transition-transform duration-500 ease-out ${zoomClass}`}
+              />
+
+              {showTitles && (
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
+              )}
+
+              {showTitles && (
+                <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
+                  <div className="transform transition-transform duration-300 group-hover:translate-y-[-4px]">
+                    <h3 className="text-2xl md:text-3xl font-serif font-medium mb-1 tracking-wide">
+                      {product.title}
+                    </h3>
+                    {product.subtitle && (
+                      <p className="text-lg font-light opacity-90">
+                        {product.subtitle}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 transition-colors duration-300" />
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProductShowcase;

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -99,6 +99,33 @@ const Index = () => {
     },
   ];
 
+  const productShowcaseItems: ProductItem[] = [
+    {
+      title: "The Linen",
+      subtitle: "Shirt",
+      image:
+        "https://images.pexels.com/photos/6276012/pexels-photo-6276012.jpeg",
+      href: "/collections/shirts/linen-shirt",
+      alt: "White linen shirt",
+    },
+    {
+      title: "The White",
+      subtitle: "Dress",
+      image:
+        "https://images.pexels.com/photos/1887465/pexels-photo-1887465.jpeg",
+      href: "/collections/dresses/white-dress",
+      alt: "White summer dress",
+    },
+    {
+      title: "The Wicker",
+      subtitle: "Bag",
+      image:
+        "https://images.pexels.com/photos/8365688/pexels-photo-8365688.jpeg",
+      href: "/collections/accessories/wicker-bag",
+      alt: "Wicker handbag",
+    },
+  ];
+
   return (
     <div className="min-h-screen bg-background">
       <Navigation />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -158,6 +158,25 @@ const Index = () => {
         collections={collections}
       />
 
+      <div className="py-16 bg-white">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl lg:text-4xl font-serif font-semibold mb-4">
+              Signature Pieces
+            </h2>
+            <p className="text-muted-foreground max-w-2xl mx-auto">
+              Our most beloved designs that define the essence of timeless style
+              and quality craftsmanship.
+            </p>
+          </div>
+          <ProductShowcase
+            products={productShowcaseItems}
+            zoomScale={1.08}
+            gap="gap-2"
+          />
+        </div>
+      </div>
+
       <CallToActionSection
         badge="Style Guide"
         title="The Summer Style Guide"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -135,10 +135,18 @@ const Index = () => {
         title="Timeless Style,"
         highlightedText="Modern Living"
         description="Discover our curated collection of classic American clothing designed for life's memorable moments."
-        primaryButtonText="Shop New Arrivals"
-        primaryButtonHref="/collections/new-arrivals"
-        secondaryButtonText="View Style Guide"
-        secondaryButtonHref="/style-guide"
+        buttons={[
+          {
+            text: "Shop New Arrivals",
+            href: "/collections/new-arrivals",
+            variant: "default",
+          },
+          {
+            text: "View Style Guide",
+            href: "/style-guide",
+            variant: "outline",
+          },
+        ]}
         image="https://images.pexels.com/photos/27733947/pexels-photo-27733947.jpeg"
         imageAlt="Spring Collection Hero"
       />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -10,6 +10,7 @@ import CallToActionSection, {
   ActionButton,
 } from "@/components/CallToActionSection";
 import FeaturesSection, { Feature } from "@/components/FeaturesSection";
+import ProductShowcase, { ProductItem } from "@/components/ProductShowcase";
 
 const Index = () => {
   const featuredProducts: Product[] = [

--- a/client/pages/StyleGuide.tsx
+++ b/client/pages/StyleGuide.tsx
@@ -115,10 +115,18 @@ const StyleGuide = () => {
         title="The Summer"
         highlightedText="Style Guide"
         description="Discover effortless elegance for the season ahead. From coastal getaways to city adventures, find pieces that move with you through every summer moment."
-        primaryButtonText="Shop the Collection"
-        primaryButtonHref="/collections/all"
-        secondaryButtonText="Download Guide"
-        secondaryButtonHref="#download"
+        buttons={[
+          {
+            text: "Shop the Collection",
+            href: "/collections/all",
+            variant: "default",
+          },
+          {
+            text: "Download Guide",
+            href: "#download",
+            variant: "outline",
+          },
+        ]}
         image="https://images.pexels.com/photos/32796818/pexels-photo-32796818.jpeg"
         imageAlt="Summer Style Guide"
         backgroundColor="bg-gradient-to-r from-blue-50 to-green-50"


### PR DESCRIPTION
This pull request adds a new ProductShowcase component and reformats the builder registry configuration.

Changes made:
- Added new ProductShowcase component with TypeScript interfaces for product items
- Imported and registered ProductShowcase in builder-registry.ts
- Reformatted builder registry configuration with improved code formatting and multi-line object properties
- Updated HeroSection component usage to use buttons array instead of separate button props
- Integrated ProductShowcase into Index page with signature pieces section
- Updated StyleGuide page to use new HeroSection button format

The ProductShowcase component provides a flexible way to display product collections with hover effects, customizable layouts, and optional titles.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/05efc8254aa64de89a8136dc6d4ece4c/quantum-verse)

👀 [Preview Link](https://05efc8254aa64de89a8136dc6d4ece4c-quantum-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>05efc8254aa64de89a8136dc6d4ece4c</projectId>-->
<!--<branchName>quantum-verse</branchName>-->